### PR TITLE
Use new SymPDE's mapped domain (#6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
-sudo: required
+os: linux
+dist: xenial
 language: python
 
 # which python versions to test
 python:
-  - "3.5"
-  - "3.6"
-
-# Enable 3.7 without globally enabling 'dist: xenial' for other build jobs
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
 
 # Cache directory $HOME/.cache/pip
 cache: pip
@@ -23,7 +20,7 @@ before_install:
 
 # command to install project
 install:
-  - python -m pip install .
+  - python -m pip install . --use-feature=2020-resolver
 
 # command to run tests
 script:

--- a/gelato/expr.py
+++ b/gelato/expr.py
@@ -21,7 +21,7 @@ from sympde.expr import AdvectionT as AdvectionTForm
 from sympde.expr import Bilaplacian as BilaplacianForm
 from sympde.expr import Basic1dForm
 from sympde.topology import SymbolicExpr
-from sympde.topology import SymbolicDeterminant
+from sympde.calculus.matrices import SymbolicDeterminant
 from sympde.topology.space import ScalarField, VectorField
 
 from .glt import (BasicGlt, Mass, Stiffness,
@@ -29,7 +29,7 @@ from .glt import (BasicGlt, Mass, Stiffness,
 
 
 def gelatize(a, degrees=None, n_elements=None, evaluate=False, mapping=None,
-             human=False):
+             human=False, expand=False):
 
     if not isinstance(a, BilinearForm):
         raise TypeError('> Expecting a BilinearForm')
@@ -37,7 +37,7 @@ def gelatize(a, degrees=None, n_elements=None, evaluate=False, mapping=None,
     dim = a.ldim
 
     # ... compute tensor form
-    expr = TensorExpr(a, mapping=mapping)
+    expr = TensorExpr(a, mapping=mapping, expand=expand)
     # ...
 
     # ...
@@ -125,7 +125,7 @@ def gelatize(a, degrees=None, n_elements=None, evaluate=False, mapping=None,
     # ...
     if mapping and human:
         expr *= SymbolicDeterminant(mapping)
-        expr = SymbolicExpr(expr)
+        expr  = SymbolicExpr(expr)
     # ...
 
     return expr
@@ -146,9 +146,8 @@ class GltExpr(Expr):
 
         fourier_vars = [Symbol(i) for i in ['tx', 'ty', 'tz'][:dim]]
 #        space_vars   = [Symbol(i) for i in ['x', 'y', 'z'][:dim]]
-
-        atoms = form.atoms(Symbol)
-        space_vars   = [i for i in atoms if i.name in ['x', 'y', 'z']]
+        atoms  = form.atoms(Symbol)
+        space_vars   = [i for i in atoms if i in form.coordinates]
         # ...
 
         return Basic.__new__(cls, fourier_vars, space_vars, form)

--- a/gelato/tests/test_bilinear_2d.py
+++ b/gelato/tests/test_bilinear_2d.py
@@ -74,14 +74,16 @@ def test_bilinear_2d_mapping_1():
 
     M = Mapping('M', DIM)
 
-    V = ScalarFunctionSpace('V', domain)
+    mapped_domain = M(domain)
+
+    V = ScalarFunctionSpace('V', mapped_domain)
 
     u,v = elements_of(V, names='u,v')
 
     c = Constant('c')
 
     expr = dot(grad(v), grad(u)) + c*v*u
-    expr = BilinearForm((u,v), integral(domain, expr))
+    expr = BilinearForm((u,v), integral(mapped_domain, expr))
 
     print('> input     >>> {0}'.format(expr))
     print('> gelatized >>> {0}'.format(gelatize(expr, mapping=M, human=True)))
@@ -92,14 +94,16 @@ def test_bilinear_2d_mapping_2():
 
     M = Mapping('M', DIM)
 
-    V = VectorFunctionSpace('V', domain)
+    mapped_domain = M(domain)
+
+    V = VectorFunctionSpace('V', mapped_domain)
 
     u,v = elements_of(V, names='u,v')
 
     c = Constant('c')
 
     expr = c * div(v) * div(u) + curl(v) * curl(u)
-    expr = BilinearForm((u,v), integral(domain, expr))
+    expr = BilinearForm((u,v), integral(mapped_domain, expr))
 
     print('> input     >>> {0}'.format(expr))
     print('> gelatized >>> {0}'.format(gelatize(expr, mapping=M, human=True)))

--- a/gelato/tests/test_bilinear_3d.py
+++ b/gelato/tests/test_bilinear_3d.py
@@ -28,14 +28,16 @@ def test_bilinear_3d_mapping_1():
 
     M = Mapping('M', DIM)
 
-    V = ScalarFunctionSpace('V', domain)
+    mapped_domain = M(domain)
+
+    V = ScalarFunctionSpace('V', mapped_domain)
 
     u,v = elements_of(V, names='u,v')
 
     c = Constant('c')
 
     expr = dot(grad(v), grad(u)) + c*v*u
-    expr = BilinearForm((u,v), integral(domain, expr))
+    expr = BilinearForm((u,v), integral(mapped_domain, expr))
 
     print('> input     >>> {0}'.format(expr))
     print('> gelatized >>> {0}'.format(gelatize(expr, mapping=M, human=True)))
@@ -48,14 +50,16 @@ def test_bilinear_3d_mapping_2():
 
     M = Mapping('M', DIM)
 
-    V = VectorFunctionSpace('V', domain)
+    mapped_domain = M(domain)
+
+    V = VectorFunctionSpace('V', mapped_domain)
 
     u,v = elements_of(V, names='u,v')
 
     c = Constant('c')
 
     expr = c * div(v) * div(u) + dot(curl(v), curl(u))
-    expr = BilinearForm((u,v), integral(domain, expr))
+    expr = BilinearForm((u,v), integral(mapped_domain, expr))
 
     print('> input     >>> {0}'.format(expr))
     print('> gelatized >>> {0}'.format(gelatize(expr, mapping=M, human=True)))

--- a/gelato/tests/test_gelatize_1d.py
+++ b/gelato/tests/test_gelatize_1d.py
@@ -10,7 +10,7 @@ from sympy import I
 from sympde.core import Constant
 from sympde.calculus import grad, dot, inner, cross, rot, curl, div
 from sympde.calculus import laplace, hessian, bracket, convect
-from sympde.topology import (dx, dy, dz)
+from sympde.topology import dx, dy, dz, dx1, dx2, dx3
 from sympde.topology import ScalarFunctionSpace
 from sympde.topology import Domain
 from sympde.topology import elements_of
@@ -75,7 +75,7 @@ def test_gelatize_1d_3():
 
     expected = I*Advection(px,tx)
 
-    expr = dx(u) * v
+    expr = dx1(u) * v
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 
@@ -98,7 +98,7 @@ def test_gelatize_1d_4():
 
     expected = c1*Mass(px,tx)/nx + c2*I*Advection(px,tx) - c3*I*Advection(px,tx) + c4*nx*Stiffness(px,tx)
 
-    expr = c1*v*u + c2*dx(u)*v + c3*dx(v)*u + c4*dx(v)*dx(u)
+    expr = c1*v*u + c2*dx1(u)*v + c3*dx1(v)*u + c4*dx1(v)*dx1(u)
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 

--- a/gelato/tests/test_gelatize_2d.py
+++ b/gelato/tests/test_gelatize_2d.py
@@ -10,7 +10,7 @@ from sympy import I
 from sympde.core import Constant
 from sympde.calculus import grad, dot, inner, cross, rot, curl, div
 from sympde.calculus import laplace, hessian, bracket, convect
-from sympde.topology import (dx, dy, dz)
+from sympde.topology import dx1, dx2, dx3
 from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
 from sympde.topology import Domain
 from sympde.topology import Mapping
@@ -59,7 +59,7 @@ def test_gelatize_2d_2():
 
     expected = Mass(py,ty)*nx*Stiffness(px,tx)/ny
 
-    expr = dx(u)*dx(v)
+    expr = dx1(u)*dx1(v)
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 
@@ -77,7 +77,7 @@ def test_gelatize_2d_3():
 
     expected = I*Advection(py,ty)*Mass(px,tx)/nx
 
-    expr = dy(u) * v
+    expr = dx2(u) * v
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 
@@ -95,7 +95,7 @@ def test_gelatize_2d_4():
 
     expected = I*Advection(px,tx)*Mass(py,ty)/ny
 
-    expr = dx(u) * v
+    expr = dx1(u) * v
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 
@@ -134,7 +134,7 @@ def test_gelatize_2d_6():
                 ny*Mass(px,tx)*Stiffness(py,ty)/nx +
                 I*Advection(py,ty)*Mass(px,tx)/nx)
 
-    expr = dot(grad(v), grad(u)) + dx(u)*v + dy(u)*v
+    expr = dot(grad(v), grad(u)) + dx1(u)*v + dx2(u)*v
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 

--- a/gelato/tests/test_gelatize_3d.py
+++ b/gelato/tests/test_gelatize_3d.py
@@ -10,7 +10,7 @@ from sympy import I
 from sympde.core import Constant
 from sympde.calculus import grad, dot, inner, cross, rot, curl, div
 from sympde.calculus import laplace, hessian, bracket, convect
-from sympde.topology import (dx, dy, dz)
+from sympde.topology import dx1, dx2, dx3
 from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
 from sympde.topology import Domain
 from sympde.topology import Mapping
@@ -58,7 +58,7 @@ def test_gelatize_3d_2():
 
     expected = nx*Mass(py,ty)*Mass(pz,tz)*Stiffness(px,tx)/(ny*nz)
 
-    expr = dx(u)*dx(v)
+    expr = dx1(u)*dx1(v)
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 
@@ -76,7 +76,7 @@ def test_gelatize_3d_3():
 
     expected = I*Advection(py,ty)*Mass(px,tx)*Mass(pz,tz)/(nx*nz)
 
-    expr = dy(u) * v
+    expr = dx2(u) * v
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 
@@ -94,7 +94,7 @@ def test_gelatize_3d_4():
 
     expected = I*Advection(px,tx)*Mass(py,ty)*Mass(pz,tz)/(ny*nz)
 
-    expr = dx(u) * v
+    expr = dx1(u) * v
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 
@@ -136,7 +136,7 @@ def test_gelatize_3d_6():
                 I*Advection(py,ty)*Mass(px,tx)*Mass(pz,tz)/(nx*nz) +
                 nz*Mass(px,tx)*Mass(py,ty)*Stiffness(pz,tz)/(nx*ny))
 
-    expr = dot(grad(v), grad(u)) + dx(u)*v + dy(u)*v
+    expr = dot(grad(v), grad(u)) + dx1(u)*v + dx2(u)*v
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     'matplotlib',
 
     # Our libraries from PyPi
-    'sympde',
+    'sympde>=0.10',
 ]
 
 # ...


### PR DESCRIPTION
This PR depends on the changes in SymPDE given by PR #71, where we add the notion of a mapped domain and a non-mapped domain is considered as a logical domain.

List of detailed changes:

* Add expand keyword to gelatize() function
* Create function space from mapped domain
* Use the correct coordinates (logical vs. physical)
* Import SymbolicDeterminant from the right place
* Update tests
* Update .travis.yml:
     . Do not use "sudo"
     . Also test on Python-3.8
     . Always use Linux Xenial (16.04)
     . Use new pip dependency resolver
* Set SymPDE minimum version to 0.10 in setup.py

Co-authored-by: Yaman Güçlü <yaman.guclu@gmail.com>