### PR TITLE
retrieve domain from BilinearForm

### DIFF
--- a/gelato/expr.py
+++ b/gelato/expr.py
@@ -31,9 +31,10 @@ def gelatize(a, degrees=None, n_elements=None, evaluate=False, mapping=None,
         raise TypeError('> Expecting a BilinearForm')
 
     dim = a.ldim
+    domain = a.domain
 
     # ... compute tensor form
-    expr = TensorExpr(a, mapping=mapping, expand=expand)
+    expr = TensorExpr(a, domain=domain, mapping=mapping, expand=expand)
     # ...
 
     # ...


### PR DESCRIPTION
Since the latest changes in sympde, `TerminalExpr`, and therefor `TensorExpr`, needs to pass the domain as an argument.
In `gelatize`, we can retrieve the domain from the `BilinearForm` directly.