### PR TITLE
GLT symbol of bilinear forms containing boundary integrals

### DIFF
--- a/gelato/tests/test_gelatize_1d.py
+++ b/gelato/tests/test_gelatize_1d.py
@@ -12,7 +12,7 @@ from sympde.calculus import grad, dot, inner, cross, rot, curl, div
 from sympde.calculus import laplace, hessian, bracket, convect
 from sympde.topology import dx, dy, dz, dx1, dx2, dx3
 from sympde.topology import ScalarFunctionSpace
-from sympde.topology import Domain
+from sympde.topology import Domain, Line
 from sympde.topology import elements_of
 from sympde.expr import BilinearForm
 from sympde.expr import integral
@@ -100,6 +100,42 @@ def test_gelatize_1d_4():
 
     expr = c1*v*u + c2*dx1(u)*v + c3*dx1(v)*u + c4*dx1(v)*dx1(u)
     expr = BilinearForm((u,v), integral(domain, expr))
+    assert(gelatize(expr) == expected)
+
+#==============================================================================
+def test_gelatize_1d_5():
+    domain = Line('Omega', bounds=(0,1))
+
+    V = ScalarFunctionSpace('V', domain)
+
+    u,v = elements_of(V, names='u,v')
+
+    expected = 0.0
+
+    expr = u*v
+    expr = BilinearForm((u,v), integral(domain.boundary, expr))
+
+    assert(gelatize(expr) == expected)
+
+#==============================================================================
+def test_gelatize_1d_6():
+    domain = Line('Omega', bounds=(0,1))
+
+    V = ScalarFunctionSpace('V', domain)
+
+    u,v = elements_of(V, names='u,v')
+
+    nx = symbols('nx', integer=True)
+    px = symbols('px', integer=True)
+    tx = symbols('tx')
+
+    expected = nx*Stiffness(px,tx)
+
+    expr = dot(grad(v), grad(u))
+
+    expr = BilinearForm((u,v), integral(domain.boundary, u*v) +
+                        integral(domain, expr))
+
     assert(gelatize(expr) == expected)
 
 #==============================================================================

--- a/gelato/tests/test_gelatize_2d.py
+++ b/gelato/tests/test_gelatize_2d.py
@@ -12,7 +12,7 @@ from sympde.calculus import grad, dot, inner, cross, rot, curl, div
 from sympde.calculus import laplace, hessian, bracket, convect
 from sympde.topology import dx1, dx2, dx3
 from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
-from sympde.topology import Domain
+from sympde.topology import Domain, Square
 from sympde.topology import Mapping
 from sympde.topology import elements_of
 from sympde.expr import BilinearForm
@@ -161,8 +161,44 @@ def test_gelatize_2d_7():
     assert(gelatize(expr) == expected)
 
 #==============================================================================
+def test_gelatize_2d_8():
+    domain = Square('Omega', bounds1=(0,1), bounds2=(0,1))
+
+    V = ScalarFunctionSpace('V', domain)
+
+    u,v = elements_of(V, names='u,v')
+
+    expected = 0.0
+
+    expr = u*v
+    expr = BilinearForm((u,v), integral(domain.boundary, expr))
+
+    assert(gelatize(expr) == expected)
+
+#==============================================================================
+def test_gelatize_2d_9():
+    domain = Square('Omega', bounds1=(0,1), bounds2=(0,1))
+
+    V = ScalarFunctionSpace('V', domain)
+
+    u,v = elements_of(V, names='u,v')
+
+    nx, ny = symbols('nx ny', integer=True)
+    px, py = symbols('px py', integer=True)
+    tx, ty = symbols('tx ty')
+
+    expected = Mass(px,tx)*ny*Stiffness(py,ty)/nx + Mass(py,ty)*nx*Stiffness(px,tx)/ny
+
+    expr = dot(grad(v), grad(u))
+
+    expr = BilinearForm((u,v), integral(domain.boundary, u*v) +
+                        integral(domain, expr))
+
+    assert(gelatize(expr) == expected)
+
+#==============================================================================
 ## TODO
-#def test_gelatize_2d_8():
+#def test_gelatize_2d_10():
 #    domain = Domain('Omega', dim=DIM)
 #
 #    V = ScalarFunctionSpace('V', domain)

--- a/gelato/tests/test_gelatize_3d.py
+++ b/gelato/tests/test_gelatize_3d.py
@@ -12,7 +12,7 @@ from sympde.calculus import grad, dot, inner, cross, rot, curl, div
 from sympde.calculus import laplace, hessian, bracket, convect
 from sympde.topology import dx1, dx2, dx3
 from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
-from sympde.topology import Domain
+from sympde.topology import Domain, Cube
 from sympde.topology import Mapping
 from sympde.topology import elements_of
 from sympde.expr import BilinearForm
@@ -165,6 +165,43 @@ def test_gelatize_3d_7():
     expr = BilinearForm((u,v), integral(domain, expr))
     assert(gelatize(expr) == expected)
 
+#==============================================================================
+def test_gelatize_3d_8():
+    domain = Cube('Omega', bounds1=(0,1), bounds2=(0,1), bounds3=(0,1))
+
+    V = ScalarFunctionSpace('V', domain)
+
+    u,v = elements_of(V, names='u,v')
+
+    expected = 0.0
+
+    expr = u*v
+    expr = BilinearForm((u,v), integral(domain.boundary, expr))
+
+    assert(gelatize(expr) == expected)
+
+#==============================================================================
+def test_gelatize_3d_9():
+    domain = Cube('Omega', bounds1=(0,1), bounds2=(0,1), bounds3=(0,1))
+
+    V = ScalarFunctionSpace('V', domain)
+
+    u,v = elements_of(V, names='u,v')
+
+    nx, ny, nz = symbols('nx ny nz', integer=True)
+    px, py, pz = symbols('px py pz', integer=True)
+    tx, ty, tz = symbols('tx ty tz')
+
+    expected = ( nx*Mass(py,ty)*Mass(pz,tz)*Stiffness(px,tx)/(ny*nz) +
+                ny*Mass(px,tx)*Mass(pz,tz)*Stiffness(py,ty)/(nx*nz) +
+                nz*Mass(px,tx)*Mass(py,ty)*Stiffness(pz,tz)/(nx*ny))
+
+    expr = dot(grad(v), grad(u))
+
+    expr = BilinearForm((u,v), integral(domain.boundary, u*v) +
+                        integral(domain, expr))
+
+    assert(gelatize(expr) == expected)
 
 #==============================================================================
 ## TODO


### PR DESCRIPTION
The GLT symbol was not computed correctly when a bilinear form contained a boundary integral. The desired behaviour is:
- `gelatize`  of a bilinear form involving only boundary integrals should return zero.
- in the case of having a bilinear form involving the sum of boundary integrals and domain integrals, `gelatize` should only be applied to the sum of domain integrals.